### PR TITLE
Hide glossary side nav

### DIFF
--- a/apps/digital-standards/src/pages/service-glossary.astro
+++ b/apps/digital-standards/src/pages/service-glossary.astro
@@ -3,6 +3,6 @@ import Layout from '../layouts/Layout.astro';
 import GlossaryPage from './service-glossary/index';
 ---
 
-<Layout>
+<Layout hideNav>
     <GlossaryPage client:load />
 </Layout>

--- a/apps/digital-standards/src/pages/service-glossary.astro
+++ b/apps/digital-standards/src/pages/service-glossary.astro
@@ -3,6 +3,6 @@ import Layout from '../layouts/Layout.astro';
 import GlossaryPage from './service-glossary/index';
 ---
 
-<Layout hideNav>
+<Layout hideNav={true}>
     <GlossaryPage client:load />
 </Layout>


### PR DESCRIPTION
Side nav removed.
![service-glossary-without sideNav](https://github.com/user-attachments/assets/b3d49078-2171-4c3e-9c43-44a579955432)
