### PR TITLE
Removed the word "standard" from the landing page

### DIFF
--- a/apps/common-capabilities/src/pages/landing/index.tsx
+++ b/apps/common-capabilities/src/pages/landing/index.tsx
@@ -16,7 +16,7 @@ export default function Landing(): JSX.Element {
   return (
     <div>
       <GoAHeroBanner
-        heading="Discover standard services designed for product teams within GoA"
+        heading="Discover services designed for product teams within GoA"
         minHeight="20%"
         textColor="#333333"
         backgroundColor="#F1F1F1"


### PR DESCRIPTION
![landingPage](https://github.com/user-attachments/assets/3627a653-579b-4b96-8268-3b102f226a7c)
