### PR TITLE
fix: removing redundant headers when no data exists for section

### DIFF
--- a/apps/common-capabilities/src/pages/services/details/config.ts
+++ b/apps/common-capabilities/src/pages/services/details/config.ts
@@ -104,40 +104,46 @@ export const specifications = {
     }
 }
 
+/**
+ * dataIn indicates the property where the item should be found in list of array form.
+ * each property in the array can be of a path to the data in case of nested objects
+ * i.e.
+ * {a: {b: {c: 1}}}
+ * dataIn: ['a'] -> {b: {c: 1}}
+ * dataIn: ['a.b'] -> {c: 1}
+ * dataIn: ['a.b.c'] -> 1
+ */
 export const bodyItems = {
     "specs": {
         "title": "Specifications",
-        "dataIn": ""
+        "dataIn": Object.keys(specifications)
     },
     "roadmap": {
         "title": "Roadmap",
-        "dataIn": ""
+        "dataIn": null
     },
     "prerequisites": {
         "title": "Prerequisites",
-        "dataIn": ""
+        "dataIn": null
     },
     "useCases": {
         "title": "Use cases",
-        "dataIn": ""
+        "dataIn": null
     },
     "documentation": {
         "title": "Documentation",
-        "dataIn": ""
+        "dataIn": null
     },
     "comments": {
         "title": "Additional information",
-        "dataIn": ""
+        "dataIn": null
     },
     "security": {
         "title": "Security and compliance",
-        "dataIn": ""
+        "dataIn": securityGroups.flatMap(group => group.items)
     },
     "contact": {
         "title": "Contact",
-        "dataIn": "methods"
+        "dataIn": ["contact.methods"]
     }
 }
-
-
- // import {securityGroups, securityData, specifications, bodyItems} from './config' 

--- a/apps/common-capabilities/src/pages/services/details/index.tsx
+++ b/apps/common-capabilities/src/pages/services/details/index.tsx
@@ -25,6 +25,18 @@ type ServiceDetailsResponse = {
   serviceInfo: any;
 }
 
+interface SecurityItem {
+  name: string;
+  title: string;
+  tableTh: any;
+  dataSecurityType: string;
+  note: string;
+}
+
+function get(obj: any, path: string) {
+  return path.split('.').reduce((acc, key: string) => acc?.[key], obj); 
+}
+
 export default function Details(): JSX.Element {
   const id = useMemo(() => {
     const urlSearchParams = new URLSearchParams(window.location.search);
@@ -56,7 +68,9 @@ export default function Details(): JSX.Element {
     if (app) {
       let showContent: any = [];
       Object.entries(bodyItems).forEach(([name, obj]) => {
-        if (obj.dataIn == '' ? app[name] != '' : app[name][obj.dataIn] != '') {
+        const hasData = obj.dataIn ? obj.dataIn.some((path) => get(app, path)) : app[name];
+        // const hasData = obj.dataIn ? app[name][obj.dataIn] != '' : app[name] !== ''
+        if (hasData) {
           const newValue = {
             ...obj,
             id: `body-${name.toLowerCase()}`,
@@ -81,14 +95,6 @@ export default function Details(): JSX.Element {
       });
     }
   }, [app]);
-
-  interface SecurityItem {
-    name: string;
-    title: string;
-    tableTh: any;
-    dataSecurityType: string;
-    note: string;
-  }
 
   const SecurityBlock: React.FC<{ group: SecurityItem }> = ({ group }) => {
 


### PR DESCRIPTION
- refactored some logic around displaying of service content

before:
![image](https://github.com/user-attachments/assets/876babd9-6c7a-4a36-879a-6818a1c98865)


after:

![image](https://github.com/user-attachments/assets/7bc0bfbe-50bd-4b76-9983-140392c7bf0e)
