### PR TITLE
feat: adding back button to service form page

### DIFF
--- a/apps/common-capabilities/src/components/BackButton.tsx
+++ b/apps/common-capabilities/src/components/BackButton.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { GoAButton } from "@abgov/react-components";
+
+type BackButtonProps = {
+    text?: string;
+    onClick?: () => void;
+};
+
+export default function BackButton({ text, onClick }: BackButtonProps) {
+    return (
+        <GoAButton
+            type="tertiary"
+            size="compact"
+            leadingIcon="arrow-back"
+            onClick={onClick}
+        >
+            {text}
+        </GoAButton>
+    );
+}

--- a/apps/common-capabilities/src/components/ServiceForm/ServiceFormWrapper.tsx
+++ b/apps/common-capabilities/src/components/ServiceForm/ServiceFormWrapper.tsx
@@ -7,6 +7,7 @@ import useFetch from '../../hooks/useFetch';
 import { JsonSchema, UISchemaElement } from '@jsonforms/core';
 
 type ServiceFormWrapperProps = {
+    backLink?: JSX.Element;
     pageHeader: string;
     service?: Service;
     handleSubmit: (data: Service) => Promise<any>;
@@ -17,7 +18,7 @@ type SchemaResponse = {
   uiSchema: UISchemaElement;  
 }
 
-export default function ServiceFormWrapper({pageHeader, service, handleSubmit}: ServiceFormWrapperProps) {
+export default function ServiceFormWrapper({backLink,pageHeader, service, handleSubmit}: ServiceFormWrapperProps) {
   const schemaUrl = useMemo(() => getSchemaUrl('common-capabilities-intake'), []);
   const [data, error, isLoading] = useFetch<SchemaResponse>(schemaUrl);
 
@@ -47,6 +48,7 @@ export default function ServiceFormWrapper({pageHeader, service, handleSubmit}: 
         rightColumnWidth="8%"
         leftColumnWidth="18%"
       >
+        {backLink}
         <h1>{pageHeader}</h1>
         <div className="progress-indicator">
           <GoACircularProgress variant="inline" size="large" message="Loading form information..." visible={isLoading} />

--- a/apps/common-capabilities/src/pages/addservice/index.tsx
+++ b/apps/common-capabilities/src/pages/addservice/index.tsx
@@ -1,12 +1,23 @@
 import React from 'react';
 import ServiceFormWrapper from '../../components/ServiceForm/ServiceFormWrapper';
 import useForm from '../../hooks/useFormSubmit';
+import BackButton from '../../components/BackButton';
 
 export default function AddServicePage() {
   const { handleSubmit } = useForm();
 
+  const backLink = (
+    <BackButton
+      text="Back to listing"
+      onClick={() => {
+        history.back();
+      }}
+    />
+  );
+
   return (
     <ServiceFormWrapper
+      backLink={backLink}
       pageHeader="Add Service"
       handleSubmit={handleSubmit}
     />

--- a/apps/common-capabilities/src/pages/services/details/index.tsx
+++ b/apps/common-capabilities/src/pages/services/details/index.tsx
@@ -11,6 +11,7 @@ import {
 import React, { useEffect, useState, useMemo } from 'react';
 import './styles.css';
 import ExternalLink from '../../../components/ExternalLink';
+import BackButton from '../../../components/BackButton';
 import BackToTop from '../../../components/BackToTop';
 import {
   securityGroups,
@@ -296,15 +297,7 @@ export default function Details(): JSX.Element {
             </div>
           }
         >
-          <GoAButton
-            type="tertiary"
-            size="compact"
-            leadingIcon="arrow-back"
-            onClick={() => (window.location.href = '/services/index.html')}
-          >
-            Back to listing
-          </GoAButton>
-
+          <BackButton text="Back to listing" onClick={() => (window.location.href = '/services/index.html')} />
           <GoASpacer vSpacing="l" />
           <div className="service-heading">
           <h2>{app.serviceName}</h2>

--- a/apps/common-capabilities/src/pages/updateservice/index.tsx
+++ b/apps/common-capabilities/src/pages/updateservice/index.tsx
@@ -5,6 +5,7 @@ import useFetch from '../../hooks/useFetch';
 import { GoACircularProgress } from '@abgov/react-components';
 import useForm from '../../hooks/useFormSubmit';
 import { getApiUrl } from '../../utils/configs';
+import BackButton from '../../components/BackButton';
 
 type ServiceDetailsResponse = {
   serviceInfo: Service
@@ -29,10 +30,13 @@ export default function UpdateServicePage(): JSX.Element {
     }
   }, [data, isLoading]);
 
+  const backLink = <BackButton text="Back to details" onClick={() => { history.back(); }} />;
+
   return isLoading || !service ? (
     <GoACircularProgress variant="fullscreen" size="large" message="Loading service details..." visible={true} />
   ) : (
     <ServiceFormWrapper
+      backLink={backLink}
       pageHeader={`Update ${service.serviceName}`}
       service={service}
       handleSubmit={handleSubmit}


### PR DESCRIPTION
- adding back buttons to both add and update forms page

add service
![image](https://github.com/user-attachments/assets/29bc58fc-c1e6-4ae8-a925-b0c2114c1c1d)


update service
![image](https://github.com/user-attachments/assets/dce84725-4da2-4404-8982-adfb9031c302)
