### PR TITLE
fix: addressing issue with flashing of content for client only renders

### DIFF
--- a/apps/common-capabilities/src/layouts/ClientOnlyRenderLayout.astro
+++ b/apps/common-capabilities/src/layouts/ClientOnlyRenderLayout.astro
@@ -1,0 +1,16 @@
+---
+import Layout from './Layout.astro';
+
+export interface Props {
+  title: string;
+  contentHeight?: string;
+}
+
+const { title, contentHeight } = Astro.props;
+---
+
+<Layout title={title}>
+    <div class='skeleton' style=`min-height: ${contentHeight || "1500px"};`>
+        <slot />
+    </div>
+</Layout>

--- a/apps/common-capabilities/src/pages/addservice.astro
+++ b/apps/common-capabilities/src/pages/addservice.astro
@@ -1,8 +1,8 @@
 ---
-import Layout from '../layouts/Layout.astro';
+import Layout from '../layouts/ClientOnlyRenderLayout.astro';
 import AddServicePage from './addservice/index';
 ---
 <!--there are issues with injected css in astro (styled components used by json forms see https://github.com/withastro/astro/issues/4432-->
-<Layout title="Common capabilities-Add new">
-  <AddServicePage client:only="react" />
+<Layout title='Common capabilities-Add new' contentHeight='1500px'>
+    <AddServicePage client:only="react" />
 </Layout>

--- a/apps/common-capabilities/src/pages/services.astro
+++ b/apps/common-capabilities/src/pages/services.astro
@@ -1,8 +1,8 @@
 ---
-import Layout from '../layouts/Layout.astro';
+import Layout from '../layouts/ClientOnlyRenderLayout.astro';
 import ServicesPage from './services/index';
 ---
 
-<Layout title="Common capabilities-Services">
-  <ServicesPage client:only="react" />
+<Layout title='Common capabilities-Services' contentHeight='2000px'>
+    <ServicesPage client:only="react" />
 </Layout>

--- a/apps/common-capabilities/src/pages/updateservice.astro
+++ b/apps/common-capabilities/src/pages/updateservice.astro
@@ -1,8 +1,8 @@
 ---
-import Layout from '../layouts/Layout.astro';
+import Layout from '../layouts/ClientOnlyRenderLayout.astro';
 import UpdateServicePage from './updateservice';
 ---
 
-<Layout title="Common capabilities-Service update">
-  <UpdateServicePage client:only="react" />
+<Layout title='Common capabilities-Service update' contentHeight='1500px'>
+    <UpdateServicePage client:only="react" />
 </Layout>


### PR DESCRIPTION
- a workaround for the flashing of footer content. reason why it was happening is because the header and footer is rendered then content is loaded which then pushes the footer down.

![Commoncapabilities-GoogleChrome2024-12-0616-01-23-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/60541ed6-3e93-4b5e-b7a8-a6985730c042)
