### PR TITLE
fix: filtering out invalid roadmap entries

### DIFF
--- a/apps/common-capabilities/src/components/Roadmap/index.tsx
+++ b/apps/common-capabilities/src/components/Roadmap/index.tsx
@@ -27,9 +27,9 @@ const getImpactItems = (impacts: string) => {
 
     return (
         <ul>
-            {impacts?.split('\n').map((impact: any) => (
-                <li key={impact}>{impact}</li>
-            ))}
+            {impacts?.split('\n').map((impact: any) => {
+                return (impact && impact.trim().length > 0) ? <li key={impact}>{impact}</li> : null;
+            })}
         </ul>
     );
 }
@@ -44,6 +44,7 @@ export default function Roadmap({ roadmap }: RoadmapProps) {
                             <dt className={inlineTitle ? 'inline-title' : ''}>{title}</dt>
                             <dd>{getValue(item)}</dd>
                         </>
+                        
                     ))
                 }
             </dl>


### PR DESCRIPTION
- removing invalid entries from impact list

before:
![image](https://github.com/user-attachments/assets/4c1fe8ad-7ce5-4245-8ad0-cc24a135a12d)


after:
![image](https://github.com/user-attachments/assets/3a475d4b-4fbd-460e-ab8d-1745fec06a8c)
